### PR TITLE
feat(otel): implement OpenTelemetry Tracer + Meter Adapter

### DIFF
--- a/docs/stories/3.1.story.md
+++ b/docs/stories/3.1.story.md
@@ -1,0 +1,640 @@
+# Story 3.1: OpenTelemetry Tracer + Meter Adapter
+
+## Status
+**📝 Draft** (Created: 2025-10-03)
+
+## Story
+**As a** framework user,
+**I want** real OpenTelemetry tracing and metrics collection with automatic exemplar support,
+**so that** I can achieve full distributed observability with trace-to-metric correlation across my microservices
+
+## Acceptance Criteria
+1. OpenTelemetry adapter passes all Tracer interface tests
+2. OpenTelemetry adapter passes all Meter interface tests
+3. Automatic exemplar support linking metrics to traces
+4. OTel Logs Bridge automatically extracts TraceID from context (already implemented in Zap adapter)
+5. Exporters work with Jaeger, Prometheus, and OTLP
+6. Example application demonstrates full observability correlation
+7. Performance overhead < 5% vs NoOp implementations
+8. Test coverage >= 80%
+9. Configuration integration via `hyperion.Config`
+10. W3C Trace Context propagation for distributed tracing
+
+## Tasks / Subtasks
+
+- [ ] **Implement OTel Tracer Adapter** (AC: 1, 10)
+  - [ ] Create `adapter/otel/` package with `go.mod`
+  - [ ] Implement `otelTracer` struct wrapping `trace.Tracer`
+  - [ ] Implement `Start(ctx, spanName, opts)` method with option conversion
+  - [ ] Implement `otelSpan` wrapper for `hyperion.Span` interface
+  - [ ] Implement span methods: `End()`, `AddEvent()`, `RecordError()`, `SetAttributes()`
+  - [ ] Add option converters: `convertOpts()`, `convertEndOpts()`, `convertEventOpts()`, `convertErrorOpts()`, `convertAttributes()`
+  - [ ] Add W3C Trace Context propagation support
+  - [ ] Add unit tests for tracer (>80% coverage)
+
+- [ ] **Implement OTel Meter Adapter** (AC: 2, 3)
+  - [ ] Implement `otelMeter` struct wrapping `metric.Meter`
+  - [ ] Implement `Counter(name, opts)` method returning `otelCounter`
+  - [ ] Implement `Histogram(name, opts)` method returning `otelHistogram`
+  - [ ] Implement `Gauge(name, opts)` method returning `otelGauge`
+  - [ ] Implement `UpDownCounter(name, opts)` method returning `otelUpDownCounter`
+  - [ ] Implement `otelCounter` with `Add(ctx, value, attrs)` method
+  - [ ] Implement `otelHistogram` with `Record(ctx, value, attrs)` method
+  - [ ] Implement `otelGauge` with `Record(ctx, value, attrs)` method
+  - [ ] Implement `otelUpDownCounter` with `Add(ctx, value, attrs)` method
+  - [ ] Add automatic exemplar support (metrics include trace context from `ctx`)
+  - [ ] Add metric option builder: `buildMetricConfig(opts...)` for description and unit
+  - [ ] Add attribute converter: `convertAttributes(attrs...)`
+  - [ ] Add unit tests for all metric types (>80% coverage)
+
+- [ ] **Add Trace Exporters** (AC: 5)
+  - [ ] Implement Jaeger exporter configuration
+  - [ ] Implement OTLP exporter configuration (supports both traces and metrics)
+  - [ ] Add exporter factory pattern based on config
+  - [ ] Add unit tests for exporter initialization
+
+- [ ] **Add Metrics Exporters** (AC: 5)
+  - [ ] Implement Prometheus exporter configuration
+  - [ ] Implement OTLP metrics exporter configuration
+  - [ ] Add metrics reader configuration (periodic vs delta)
+  - [ ] Add unit tests for metrics exporter initialization
+
+- [ ] **Configuration Integration** (AC: 9)
+  - [ ] Define `TracingConfig` struct (service_name, exporter, endpoint, sample_rate, attributes)
+  - [ ] Define `MetricsConfig` struct (service_name, exporter, endpoint, interval, attributes)
+  - [ ] Implement `LoadTracingConfig(config hyperion.Config)` helper
+  - [ ] Implement `LoadMetricsConfig(config hyperion.Config)` helper
+  - [ ] Add configuration validation and defaults
+  - [ ] Add config unit tests
+
+- [ ] **fx Module Integration** (AC: 1, 2)
+  - [ ] Create `TracerModule` with `fx.Provide(NewOtelTracer, fx.As(hyperion.Tracer))`
+  - [ ] Create `MeterModule` with `fx.Provide(NewOtelMeter, fx.As(hyperion.Meter))`
+  - [ ] Add `RegisterShutdownHook` to flush traces/metrics on app shutdown
+  - [ ] Add lifecycle hooks for proper resource cleanup
+  - [ ] Add module tests
+
+- [ ] **Integration Tests** (AC: 5, 6, 7)
+  - [ ] Write integration test with Jaeger exporter (Docker)
+  - [ ] Write integration test with Prometheus exporter (Docker)
+  - [ ] Write integration test with OTLP exporter (Docker)
+  - [ ] Write integration test validating exemplar support (metrics link to traces)
+  - [ ] Write performance benchmark test (compare with NoOp baseline, verify <5% overhead)
+  - [ ] Write end-to-end test demonstrating full observability correlation
+
+- [ ] **Documentation** (AC: 6)
+  - [ ] Create `adapter/otel/README.md` with usage examples
+  - [ ] Add configuration examples (YAML)
+  - [ ] Add code examples showing interceptor pattern usage
+  - [ ] Add code examples showing manual tracing usage
+  - [ ] Add examples showing metrics with exemplars
+  - [ ] Document exporter setup (Jaeger, Prometheus, OTLP)
+  - [ ] Add Docker Compose example for local observability stack
+
+---
+
+## Dev Notes
+
+### Previous Story Context
+
+**Story 2.3 Completion** (✅ Completed 2025-10-03):
+- Implemented Interceptor pattern replacing decorator pattern
+- `ctx.UseIntercept(parts...)` now available for automatic tracing/logging/metrics
+- `TracingInterceptor` (order 100) creates spans automatically
+- `LoggingInterceptor` (order 200) logs method calls automatically
+- Zap adapter already includes OTel Logs Bridge for trace correlation
+
+**Key Insight from 2.3**:
+- Interceptor pattern is preferred over manual instrumentation
+- Built-in interceptors handle most observability needs automatically
+- Manual tracing should only be used for fine-grained control
+
+### OpenTelemetry Core Concepts
+
+[Source: docs/architecture/tech-stack.md#observability-opentelemetry]
+
+**What is OpenTelemetry?**
+- Industry-standard observability framework (CNCF project)
+- Vendor-neutral (works with Jaeger, Zipkin, Prometheus, Grafana, etc.)
+- Provides automatic correlation between traces, metrics, and logs
+- Comprehensive SDK with support for many languages
+
+**Why OpenTelemetry for Hyperion?**
+1. **Vendor Neutrality**: Users can switch observability backends without code changes
+2. **Automatic Correlation**: TraceID and SpanID shared across all three pillars
+3. **Industry Standard**: Well-documented, strong community support
+4. **Production Ready**: Used by major companies at scale
+
+**Current vs Future State**:
+- **Current (v2.0-2.2)**: Core interfaces (`hyperion.Tracer`, `hyperion.Meter`), NoOp defaults, interceptor pattern
+- **Future (v3.0)**: This story adds real OTel SDK integration for actual span/metric export
+
+### Core Interfaces to Implement
+
+[Source: hyperion/tracer.go, hyperion/metric.go]
+
+**`hyperion.Tracer` Interface**:
+```go
+type Tracer interface {
+    Start(ctx context.Context, spanName string, opts ...SpanOption) (context.Context, Span)
+}
+
+type Span interface {
+    End(options ...SpanEndOption)
+    AddEvent(name string, options ...EventOption)
+    RecordError(err error, options ...EventOption)
+    SetAttributes(attributes ...Attribute)
+}
+```
+
+**`hyperion.Meter` Interface**:
+```go
+type Meter interface {
+    Counter(name string, opts ...MetricOption) Counter
+    Histogram(name string, opts ...MetricOption) Histogram
+    Gauge(name string, opts ...MetricOption) Gauge
+    UpDownCounter(name string, opts ...MetricOption) UpDownCounter
+}
+
+type Counter interface {
+    Add(ctx context.Context, value int64, attrs ...Attribute)
+}
+
+type Histogram interface {
+    Record(ctx context.Context, value float64, attrs ...Attribute)
+}
+
+type Gauge interface {
+    Record(ctx context.Context, value float64, attrs ...Attribute)
+}
+
+type UpDownCounter interface {
+    Add(ctx context.Context, value int64, attrs ...Attribute)
+}
+```
+
+### Option Types to Convert
+
+[Source: hyperion/tracer.go, hyperion/metric.go]
+
+**Span Options**:
+- `SpanOption` → OTel `trace.SpanStartOption`
+- `SpanEndOption` → OTel `trace.SpanEndOption`
+- `EventOption` → OTel `trace.EventOption`
+- `Attribute` → OTel `attribute.KeyValue`
+
+**Metric Options**:
+- `MetricOption` → OTel `metric.InstrumentOption` (description, unit)
+- `Attribute` → OTel `attribute.KeyValue`
+
+**Helper Functions Needed**:
+```go
+// Convert hyperion options to OTel options
+func convertOpts(opts ...hyperion.SpanOption) []trace.SpanStartOption
+func convertEndOpts(opts ...hyperion.SpanEndOption) []trace.SpanEndOption
+func convertEventOpts(opts ...hyperion.EventOption) []trace.EventOption
+func convertErrorOpts(opts ...hyperion.EventOption) []trace.EventOption
+func convertAttributes(attrs ...hyperion.Attribute) []attribute.KeyValue
+
+// Build metric configuration from options
+func buildMetricConfig(opts ...hyperion.MetricOption) metricConfig
+type metricConfig struct {
+    Description string
+    Unit        string
+}
+```
+
+### Exemplar Support (Automatic Trace Correlation)
+
+[Source: docs/prd/epic-3-observability-stack.md#automatic-exemplar-support]
+
+**What are Exemplars?**
+- Sample data points in metrics that link back to specific traces
+- Allows jumping from a metric spike directly to the trace that caused it
+- Automatic in OTel when both tracer and meter use the same context
+
+**Implementation**:
+- When `counter.Add(ctx, value)` is called, OTel automatically extracts TraceID and SpanID from `ctx`
+- No extra code needed - works automatically if context has an active span
+- Exemplars are exported alongside metrics to Prometheus or OTLP backend
+
+**Example**:
+```go
+func (s *UserService) GetUser(ctx hyperion.Context, id string) (*User, error) {
+    // Interceptor creates span automatically
+    ctx, end := ctx.UseIntercept("UserService", "GetUser")
+    defer end(&err)
+
+    // Metric automatically includes exemplar (current trace)
+    counter := ctx.Meter().Counter("user.lookups")
+    counter.Add(ctx, 1)  // ← Exemplar is automatic!
+
+    return s.userRepo.FindByID(ctx, id)
+}
+```
+
+### W3C Trace Context Propagation
+
+[Source: docs/prd/epic-3-observability-stack.md#distributed-context-propagation]
+
+**What is W3C Trace Context?**
+- Standard HTTP headers for passing trace context between services
+- Headers: `traceparent` (TraceID + SpanID), `tracestate` (vendor data)
+- Enables distributed tracing across multiple services/languages
+
+**OTel Support**:
+- OTel SDK handles W3C propagation automatically
+- `propagation.TraceContext{}` propagator extracts/injects headers
+- Works with HTTP, gRPC, message queues, etc.
+
+**No Extra Work Needed**:
+- OTel SDK configures W3C propagation by default
+- Future hyperweb/hypergrpc will handle header injection/extraction
+- For this story, just ensure OTel SDK is configured correctly
+
+### Configuration Structure
+
+[Source: docs/prd/epic-3-observability-stack.md#configuration-example]
+
+**Tracing Configuration** (from `hyperion.Config`):
+```yaml
+tracing:
+  enabled: true
+  service_name: my-service          # Required
+  exporter: jaeger                  # jaeger, otlp
+  endpoint: localhost:14268         # Exporter endpoint
+  sample_rate: 1.0                  # 0.0 - 1.0 (1.0 = 100%)
+  attributes:                       # Global span attributes
+    environment: production
+    version: v1.0.0
+```
+
+**Metrics Configuration**:
+```yaml
+metrics:
+  enabled: true
+  service_name: my-service          # Required
+  exporter: prometheus              # prometheus, otlp
+  endpoint: localhost:9090          # Exporter endpoint (for OTLP)
+  interval: 10s                     # Collection interval
+  attributes:                       # Global metric attributes
+    environment: production
+    version: v1.0.0
+```
+
+**Config Helpers**:
+```go
+type TracingConfig struct {
+    Enabled      bool
+    ServiceName  string
+    Exporter     string  // "jaeger", "otlp"
+    Endpoint     string
+    SampleRate   float64
+    Attributes   map[string]string
+}
+
+type MetricsConfig struct {
+    Enabled      bool
+    ServiceName  string
+    Exporter     string  // "prometheus", "otlp"
+    Endpoint     string
+    Interval     time.Duration
+    Attributes   map[string]string
+}
+
+func LoadTracingConfig(config hyperion.Config) (TracingConfig, error)
+func LoadMetricsConfig(config hyperion.Config) (MetricsConfig, error)
+```
+
+### File Locations & Structure
+
+[Source: docs/architecture/source-tree.md#adapter-implementations]
+
+**New Package**: `adapter/otel/`
+
+**Files to Create**:
+- `adapter/otel/go.mod` - Independent module
+- `adapter/otel/go.sum` - Dependencies lock file
+- `adapter/otel/tracer.go` - Tracer implementation
+- `adapter/otel/meter.go` - Meter implementation
+- `adapter/otel/span.go` - Span wrapper implementation
+- `adapter/otel/metrics.go` - Metric type implementations (Counter, Histogram, etc.)
+- `adapter/otel/exemplar.go` - Exemplar support helpers (may not need separate file)
+- `adapter/otel/config.go` - Configuration loading and validation
+- `adapter/otel/exporters.go` - Exporter factory functions
+- `adapter/otel/module.go` - fx.Module definitions
+- `adapter/otel/tracer_test.go` - Tracer unit tests
+- `adapter/otel/meter_test.go` - Meter unit tests
+- `adapter/otel/integration_test.go` - Integration tests with real exporters
+- `adapter/otel/benchmark_test.go` - Performance benchmarks
+- `adapter/otel/README.md` - Adapter documentation
+- `adapter/otel/doc.go` - Package documentation
+
+**Directory Structure**:
+```
+adapter/otel/
+├── go.mod                    # Dependencies
+├── go.sum
+├── doc.go                    # Package overview
+├── README.md                 # Usage guide
+├── tracer.go                 # Tracer implementation
+├── span.go                   # Span wrapper
+├── meter.go                  # Meter implementation
+├── metrics.go                # Counter/Histogram/Gauge/UpDownCounter
+├── config.go                 # Config loading
+├── exporters.go              # Exporter factories
+├── module.go                 # fx modules
+├── tracer_test.go            # Unit tests
+├── meter_test.go             # Unit tests
+├── integration_test.go       # Integration tests
+└── benchmark_test.go         # Performance tests
+```
+
+### Dependencies
+
+[Source: docs/architecture/tech-stack.md#observability-opentelemetry]
+
+**OpenTelemetry SDK**:
+```
+go.opentelemetry.io/otel v1.24.0
+go.opentelemetry.io/otel/trace v1.24.0
+go.opentelemetry.io/otel/metric v1.24.0
+go.opentelemetry.io/otel/sdk v1.24.0
+go.opentelemetry.io/otel/sdk/metric v1.24.0
+```
+
+**Exporters**:
+```
+go.opentelemetry.io/otel/exporters/jaeger v1.24.0
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric v1.24.0
+go.opentelemetry.io/otel/exporters/prometheus v0.46.0
+```
+
+**Hyperion Core**:
+```
+github.com/mapoio/hyperion v0.2.0  // Core interfaces
+go.uber.org/fx v1.23.0               // Dependency injection
+```
+
+### fx Module Pattern
+
+[Source: hyperion/module.go, adapter/zap/module.go, adapter/gorm/module.go]
+
+**Module Export Pattern** (follow existing adapters):
+```go
+// TracerModule provides OpenTelemetry Tracer implementation
+var TracerModule = fx.Module("hyperion.adapter.otel.tracer",
+    fx.Provide(
+        fx.Annotate(
+            NewOtelTracer,
+            fx.As(new(hyperion.Tracer)),
+        ),
+    ),
+    fx.Invoke(RegisterTracerShutdownHook),
+)
+
+// MeterModule provides OpenTelemetry Meter implementation
+var MeterModule = fx.Module("hyperion.adapter.otel.meter",
+    fx.Provide(
+        fx.Annotate(
+            NewOtelMeter,
+            fx.As(new(hyperion.Meter)),
+        ),
+    ),
+    fx.Invoke(RegisterMeterShutdownHook),
+)
+
+// Module provides both Tracer and Meter
+var Module = fx.Options(TracerModule, MeterModule)
+```
+
+**Shutdown Hook Pattern** (critical for flushing traces/metrics):
+```go
+func RegisterTracerShutdownHook(lc fx.Lifecycle, tracer hyperion.Tracer) {
+    lc.Append(fx.Hook{
+        OnStop: func(ctx context.Context) error {
+            // Flush any pending traces
+            if otelTracer, ok := tracer.(*otelTracer); ok {
+                return otelTracer.Shutdown(ctx)
+            }
+            return nil
+        },
+    })
+}
+```
+
+### Constructor Signature
+
+[Source: adapter/zap/logger.go:38, adapter/gorm/database.go:45]
+
+**Follow Existing Pattern** (Config-driven constructor):
+```go
+// NewOtelTracer creates an OpenTelemetry Tracer from configuration
+func NewOtelTracer(config hyperion.Config) (hyperion.Tracer, error) {
+    cfg, err := LoadTracingConfig(config)
+    if err != nil {
+        return nil, fmt.Errorf("failed to load tracing config: %w", err)
+    }
+
+    if !cfg.Enabled {
+        return hyperion.NewNoOpTracer(), nil
+    }
+
+    // Create exporter based on config
+    exporter, err := createTraceExporter(cfg)
+    if err != nil {
+        return nil, err
+    }
+
+    // Create TracerProvider
+    tp := sdktrace.NewTracerProvider(
+        sdktrace.WithBatcher(exporter),
+        sdktrace.WithSampler(sdktrace.TraceIDRatioBased(cfg.SampleRate)),
+        sdktrace.WithResource(resource.NewWithAttributes(
+            semconv.SchemaURL,
+            semconv.ServiceNameKey.String(cfg.ServiceName),
+        )),
+    )
+
+    tracer := tp.Tracer(cfg.ServiceName)
+    return &otelTracer{tracer: tracer, provider: tp}, nil
+}
+```
+
+### Testing Strategy
+
+[Source: docs/architecture/coding-standards.md#testing]
+
+**Unit Tests** (>80% coverage):
+- Test tracer span creation and operations
+- Test all metric types (Counter, Histogram, Gauge, UpDownCounter)
+- Test option conversion functions
+- Test configuration loading and validation
+- Test exporter factory functions
+- Use table-driven tests for multiple scenarios
+- Mock OTel SDK components where needed
+
+**Integration Tests** (with real exporters):
+- Test with Jaeger exporter (Docker container)
+- Test with Prometheus exporter (Docker container)
+- Test with OTLP exporter (Docker container)
+- Verify exemplar data is correctly exported
+- Verify W3C trace context propagation
+
+**Benchmark Tests** (<5% overhead requirement):
+- Benchmark tracer operations vs NoOp baseline
+- Benchmark metric operations vs NoOp baseline
+- Measure memory allocations
+- Verify performance is acceptable for production use
+
+**Test File Structure**:
+```
+adapter/otel/
+├── tracer_test.go              # Unit tests for tracer
+├── meter_test.go               # Unit tests for meter
+├── config_test.go              # Config loading tests
+├── integration_test.go         # Integration tests
+└── benchmark_test.go           # Performance benchmarks
+```
+
+### Example Usage Patterns
+
+[Source: docs/prd/epic-3-observability-stack.md#context-integration]
+
+**Recommended: 3-Line Interceptor Pattern** (automatic observability):
+```go
+func (s *UserService) GetUser(ctx hyperion.Context, id string) (_ *User, err error) {
+    // Automatic tracing, logging, and metrics
+    ctx, end := ctx.UseIntercept("UserService", "GetUser")
+    defer end(&err)
+
+    // Add custom metrics
+    counter := ctx.Meter().Counter("user.lookups")
+    counter.Add(ctx, 1, hyperion.String("method", "GetUser"))
+
+    return s.userRepo.FindByID(ctx, id)
+}
+```
+
+**Alternative: Manual Tracing** (fine-grained control):
+```go
+func (s *UserService) GetUserManual(ctx hyperion.Context, id string) (*User, error) {
+    ctx, span := ctx.Tracer().Start(ctx, "UserService.GetUser")
+    defer span.End()
+
+    span.SetAttributes(hyperion.String("user.id", id))
+
+    user, err := s.userRepo.FindByID(ctx, id)
+    if err != nil {
+        span.RecordError(err)
+        return nil, err
+    }
+
+    span.SetAttributes(hyperion.Bool("user.found", true))
+    return user, nil
+}
+```
+
+### Design Decisions
+
+**1. Tracer vs TracerProvider**
+- **Decision**: Expose only `hyperion.Tracer` interface, hide `TracerProvider` internally
+- **Rationale**: Simpler API, users don't need to manage provider lifecycle
+- **Implementation**: `otelTracer` struct holds both tracer and provider for shutdown
+
+**2. Option Conversion Strategy**
+- **Decision**: Convert hyperion options to OTel options at runtime
+- **Rationale**: Maintains interface compatibility, allows OTel-specific features
+- **Trade-off**: Small runtime overhead for conversion (negligible)
+
+**3. Exemplar Support**
+- **Decision**: Exemplars are automatic when context has active span
+- **Rationale**: Zero configuration, works out of the box
+- **Limitation**: Requires using `ctx` parameter consistently
+
+**4. Exporter Configuration**
+- **Decision**: Factory pattern based on string identifier ("jaeger", "otlp", "prometheus")
+- **Rationale**: Simple YAML configuration, easy to switch exporters
+- **Extensibility**: Can add new exporters without breaking changes
+
+### Success Validation
+
+Story is complete when:
+1. ✅ `otelTracer` implements `hyperion.Tracer` interface
+2. ✅ `otelMeter` implements `hyperion.Meter` interface
+3. ✅ All metric types (Counter, Histogram, Gauge, UpDownCounter) work correctly
+4. ✅ Exemplar support is automatic (verified in integration test)
+5. ✅ Jaeger, Prometheus, and OTLP exporters work (verified in integration tests)
+6. ✅ Performance overhead < 5% (verified in benchmarks)
+7. ✅ Test coverage >= 80%
+8. ✅ Configuration loading works from `hyperion.Config`
+9. ✅ fx modules integrate cleanly with CoreModule
+10. ✅ Documentation is complete with examples
+11. ✅ All linters pass (`make lint`)
+12. ✅ All tests pass (`make test`)
+
+---
+
+## Testing
+
+### Test File Locations
+- `adapter/otel/tracer_test.go` - Tracer unit tests
+- `adapter/otel/meter_test.go` - Meter unit tests
+- `adapter/otel/config_test.go` - Configuration tests
+- `adapter/otel/integration_test.go` - Integration tests with real exporters
+- `adapter/otel/benchmark_test.go` - Performance benchmarks
+
+[Source: docs/architecture/source-tree.md#adapter-implementations]
+
+### Testing Standards
+
+**Framework**: Go standard `testing` package
+
+**Test Naming**:
+- `TestOtelTracer_Start` - Tracer span creation
+- `TestOtelSpan_End` - Span operations
+- `TestOtelMeter_Counter` - Metric creation
+- `TestOtelCounter_Add` - Metric recording
+- `TestLoadTracingConfig` - Configuration loading
+- `TestIntegration_Jaeger` - Integration with Jaeger
+- `BenchmarkTracer_Start` - Performance benchmarks
+
+**Table-Driven Tests**: Use for testing multiple configurations and scenarios
+
+**Assertion Style**: Explicit error messages (`t.Errorf("got %v, want %v", got, want)`)
+
+[Source: docs/architecture/coding-standards.md#testing]
+
+### Test Coverage Target
+- Minimum: 80% (AC requirement)
+- Target: 85%+ (critical observability infrastructure)
+- Measure with: `go test -cover -coverprofile=coverage.out`
+- Report: `go tool cover -html=coverage.out`
+
+---
+
+**Story Timeline**: 10 working days (~2 weeks, as per Epic 3 plan)
+**Priority**: P1 (Foundation for full observability)
+**Assigned To**: Developer Agent
+**Epic**: Epic 3 - OpenTelemetry Integration (v3.0)
+
+---
+
+## Change Log
+
+| Date       | Version | Description              | Author        |
+|------------|---------|--------------------------|---------------|
+| 2025-10-03 | 1.0     | Initial story creation for OpenTelemetry Tracer + Meter adapter | Scrum Master Bob |
+
+---
+
+## Dev Agent Record
+
+*This section will be populated by the development agent during implementation*
+
+---
+
+## QA Results
+
+*This section will be populated by the QA agent after story completion*


### PR DESCRIPTION
## Summary
Implements real OpenTelemetry tracing and metrics collection with automatic exemplar support for full distributed observability.

## Related Issue
Closes #27

## Implementation Checklist

### Core Implementation
- [ ] Implement OTel Tracer Adapter
  - [ ] Create `adapter/otel/` package with `go.mod`
  - [ ] Implement tracer wrapper and span interface
  - [ ] Add W3C Trace Context propagation support
  - [ ] Add unit tests (>80% coverage)

- [ ] Implement OTel Meter Adapter
  - [ ] Implement meter wrapper
  - [ ] Implement all metric types (Counter, Histogram, Gauge, UpDownCounter)
  - [ ] Add automatic exemplar support
  - [ ] Add unit tests (>80% coverage)

- [ ] Add Exporters
  - [ ] Jaeger exporter configuration
  - [ ] Prometheus exporter configuration
  - [ ] OTLP exporter configuration
  - [ ] Exporter factory pattern

- [ ] Configuration Integration
  - [ ] Define TracingConfig and MetricsConfig structs
  - [ ] Implement config loading helpers
  - [ ] Add configuration validation

- [ ] fx Module Integration
  - [ ] Create TracerModule and MeterModule
  - [ ] Add shutdown hooks for flushing
  - [ ] Add lifecycle management

### Testing
- [ ] Unit tests (>80% coverage)
- [ ] Integration tests with real exporters
- [ ] Performance benchmarks (<5% overhead)
- [ ] End-to-end observability correlation test

### Documentation
- [ ] Create adapter/otel/README.md
- [ ] Add configuration examples
- [ ] Add usage examples
- [ ] Add Docker Compose for local observability stack

### Quality Gates
- [ ] All tests pass (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Test coverage >= 80%
- [ ] Performance overhead < 5%

## Test Plan
- Unit tests for all core components
- Integration tests with Jaeger, Prometheus, and OTLP
- Benchmark tests comparing with NoOp baseline
- Manual testing with example application

## Breaking Changes
None - This is a new adapter implementation